### PR TITLE
Fix description of UserSecurityReport

### DIFF
--- a/src/UserSecurityReport.php
+++ b/src/UserSecurityReport.php
@@ -59,7 +59,7 @@ class UserSecurityReport extends Report
     public function description()
     {
         return str_replace(
-            array('http', 'https', '://'),
+            array('http://', 'https://'),
             '',
             Director::protocolAndHost() . ' - ' . date('d/m/Y H:i:s')
         );


### PR DESCRIPTION
Fix https domains from being mis-labelled in the report.

Previously, https://example.com would show as sexample.com (because `http` would be stripped, then `://` would be stripped, leaving only `s` from the protocol).

|Test case|Previous result|New result|
|----------|----------------|-----------|
|http://example.com|example.com|example.com|
|https://example.com|**sexample.com**|example.com|